### PR TITLE
First working version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,54 @@
-# Mission
+Mission
+=======
 
-Provide an auto-discovery process of configurations for simple code use
+Provide an auto-discovery process of configurations for simple code use. Given a path and a list of pattern,
+the result config will be a shortcut to any config.
 
-# Predicted usage
+## Usage
 
-- Given a directory like
+Setup:
 
-        resources
-        +- config
-           +- management
-              +- billing.yaml
+    config = probe(
+        path="path/to/my/files",
+        patterns=["path/*/file.yaml"]
+    )
 
-- And a **billing.yaml** :
+Use it:
 
-        database:
-            user: "Johnny"
+    print config.mynamespace.key
 
-- When you setup your: **\_\_init__.py** to setup the quick-link
+## Parameters
 
-        config = ConfigProbe(
-            root_path="resources/",
-            patterns=["config/*/*.yaml]
-        )
+- **path**
 
-- anywhere else:
+    Initial path to probe.  Patterns will be tested against the file structure underneath the path
+    and it will be ignored in determining the namespacing.
 
-        import config
+- **patterns**
 
-        print config.management.billing.database.user
+    A list of file paths containing (or not) placeholders (*) to find where are the configuration files.
 
-        # should print "Johnny"
+    Each placeholder in the path will result in a namespace in the resulting config.  So let's say you have a pattern
+
+        dir1/*/dir2/*.yaml
+
+    If this pattern find the file : "dir1/**ns1**/dir2/**file**.yaml" that contains "key: 'value'", the resulting
+    config will be
+
+        config.ns1.file.key == "value"
+
+    now if the pattern was
+
+        dir1/ns1/dir2/file.yaml
+
+    for the same file, the resulting config would simply be
+
+        config.key == "value"
+
+    so you can use placeholders (*) to namespace the resulting config
 
 
-The patterns include * that will be used as a "namespace" and be part
-of the resulting object.  The remainder is the file loaded as a dict/object,
-structures like lists and dict will be available as dict/object or simple list.
+Contributing
+============
+
+Feel free to raise issues and send some pull request, we'll be happy to look at them!

--- a/config_probe/__init__.py
+++ b/config_probe/__init__.py
@@ -1,0 +1,40 @@
+import glob
+import json
+
+import os
+import yaml
+from munch import munchify
+
+NAMESPACE_PLACEHOLDER = "*"
+
+
+def probe(path, patterns):
+    config = {}
+
+    for pattern in patterns:
+
+        for config_file in glob.glob(os.path.join(path, pattern)):
+            relevant_part_of_the_path = config_file[len(path) + 1:]
+            path_parts, ext = os.path.splitext(relevant_part_of_the_path)
+            path_matchers, _ = os.path.splitext(pattern)
+
+            with open(config_file) as f:
+                result = _parsers[ext](f)
+
+            path_parts, current_part = os.path.split(path_parts)
+            path_matchers, matcher = os.path.split(path_matchers)
+            while current_part is not "":
+                if matcher is NAMESPACE_PLACEHOLDER:
+                    result = {current_part: result}
+                path_parts, current_part = os.path.split(path_parts)
+                path_matchers, matcher = os.path.split(path_matchers)
+
+            config.update(result)
+
+    return munchify(config)
+
+
+_parsers = {
+    ".yaml": lambda f: yaml.load(f),
+    ".json": lambda f: json.load(f),
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-bunch
+munch
+PyYAML

--- a/tests/single-file-with-namespace/stuff.json
+++ b/tests/single-file-with-namespace/stuff.json
@@ -1,0 +1,3 @@
+{
+  "key": "stuff-value"
+}

--- a/tests/single-file/stuff.yaml
+++ b/tests/single-file/stuff.yaml
@@ -1,0 +1,2 @@
+
+key: "stuff-value"

--- a/tests/test_config_probe.py
+++ b/tests/test_config_probe.py
@@ -1,0 +1,45 @@
+import unittest
+
+import os
+from config_probe import probe
+from hamcrest import is_, assert_that
+
+
+class TestConfigProbe(unittest.TestCase):
+
+    def test_single_file(self):
+        config = probe(path=_dir("single-file"),
+                       patterns=["stuff.yaml"])
+
+        assert_that(config.key, is_("stuff-value"))
+
+    def test_single_file_with_namespace(self):
+        config = probe(path=_dir("single-file-with-namespace"),
+                       patterns=["*.json"])
+
+        assert_that(config.stuff.key, is_("stuff-value"))
+
+    def test_two_files_with_subdir_namespace(self):
+        config = probe(path=_dir("two-files-with-subdir-namespace"),
+                       patterns=["*/*.yaml"])
+
+        assert_that(config.ns1.stuff.key1, is_("stuff from ns1"))
+        assert_that(config.ns2.stuff.key2, is_("stuff from ns2"))
+
+    def test_only_starred_parts_are_namespaced(self):
+        config = probe(path=_dir("two-files-with-subdir-namespace"),
+                       patterns=["*/stuff.yaml"])
+
+        assert_that(config.ns1.key1, is_("stuff from ns1"))
+        assert_that(config.ns2.key2, is_("stuff from ns2"))
+
+    def test_multiple_patterns(self):
+        config = probe(path=_dir("two-files-with-subdir-namespace"),
+                       patterns=["ns1/*.yaml", "*/stuff.yaml"])
+
+        assert_that(config.stuff.key1, is_("stuff from ns1"))
+        assert_that(config.ns2.key2, is_("stuff from ns2"))
+
+
+def _dir(name):
+    return os.path.join(os.path.dirname(os.path.realpath(__file__)), name)

--- a/tests/two-files-with-subdir-namespace/ns1/stuff.yaml
+++ b/tests/two-files-with-subdir-namespace/ns1/stuff.yaml
@@ -1,0 +1,2 @@
+
+key1: "stuff from ns1"

--- a/tests/two-files-with-subdir-namespace/ns2/stuff.yaml
+++ b/tests/two-files-with-subdir-namespace/ns2/stuff.yaml
@@ -1,0 +1,2 @@
+
+key2: "stuff from ns2"


### PR DESCRIPTION
Support single \* in patterns
Support yaml and json
Doesn't support partial \* in patterns (like file_.yaml)
Doesn't support *_
