### PR TITLE
Wrapping AttributeError and explicit support of list

### DIFF
--- a/config_probe/__init__.py
+++ b/config_probe/__init__.py
@@ -1,9 +1,11 @@
 import glob
 import json
+from config_probe.munch_wrapper import MunchWrapper
 
 import os
 import yaml
 from munch import munchify
+
 
 NAMESPACE_PLACEHOLDER = "(*)"
 
@@ -26,7 +28,7 @@ def probe(path, patterns):
 
             _add_to_configuration(config, namespaces, new_values)
 
-    return munchify(config)
+    return MunchWrapper(munchify(config))
 
 
 def fake_probe(content):

--- a/config_probe/__init__.py
+++ b/config_probe/__init__.py
@@ -4,12 +4,6 @@ import json
 import os
 import yaml
 from munch import munchify
-
-
-class ConfigNotFound(AttributeError):
-    pass
-
-
 from config_probe.munch_wrapper import MunchWrapper
 
 NAMESPACE_PLACEHOLDER = "(*)"

--- a/config_probe/__init__.py
+++ b/config_probe/__init__.py
@@ -1,11 +1,16 @@
 import glob
 import json
-from config_probe.munch_wrapper import MunchWrapper
 
 import os
 import yaml
 from munch import munchify
 
+
+class ConfigNotFound(AttributeError):
+    pass
+
+
+from config_probe.munch_wrapper import MunchWrapper
 
 NAMESPACE_PLACEHOLDER = "(*)"
 

--- a/config_probe/exceptions.py
+++ b/config_probe/exceptions.py
@@ -1,0 +1,2 @@
+class ConfigNotFound(AttributeError):
+    pass

--- a/config_probe/key_not_found_within_config_probe_patterns.py
+++ b/config_probe/key_not_found_within_config_probe_patterns.py
@@ -1,0 +1,2 @@
+class KeyNotFoundWithinConfigProbePatterns(AttributeError):
+    pass

--- a/config_probe/key_not_found_within_config_probe_patterns.py
+++ b/config_probe/key_not_found_within_config_probe_patterns.py
@@ -1,2 +1,0 @@
-class KeyNotFoundWithinConfigProbePatterns(AttributeError):
-    pass

--- a/config_probe/munch_wrapper.py
+++ b/config_probe/munch_wrapper.py
@@ -1,6 +1,6 @@
 import sys
 
-from config_probe import ConfigNotFound
+from config_probe.exceptions import ConfigNotFound
 
 
 class MunchWrapper(object):

--- a/config_probe/munch_wrapper.py
+++ b/config_probe/munch_wrapper.py
@@ -1,6 +1,6 @@
 import sys
 
-from config_probe.key_not_found_within_config_probe_patterns import KeyNotFoundWithinConfigProbePatterns
+from config_probe import ConfigNotFound
 
 
 class MunchWrapper(object):
@@ -11,7 +11,7 @@ class MunchWrapper(object):
         try:
             result = self.munch.__getattr__(item)
         except AttributeError as e:
-            raise KeyNotFoundWithinConfigProbePatterns(e)
+            raise ConfigNotFound(e)
         if type(result) in _get_primitive_type():
             return result
         return MunchWrapper(self.munch.__getattr__(item))

--- a/config_probe/munch_wrapper.py
+++ b/config_probe/munch_wrapper.py
@@ -1,0 +1,25 @@
+import sys
+
+from config_probe.key_not_found_within_config_probe_patterns import KeyNotFoundWithinConfigProbePatterns
+
+
+class MunchWrapper(object):
+    def __init__(self, munch):
+        self.munch = munch
+
+    def __getattr__(self, item):
+        try:
+            result = self.munch.__getattr__(item)
+        except AttributeError as e:
+            raise KeyNotFoundWithinConfigProbePatterns(e)
+        if type(result) in _get_primitive_type():
+            return result
+        return MunchWrapper(self.munch.__getattr__(item))
+
+
+if sys.version_info < (3,):
+    def _get_primitive_type():
+        return int, float, long, bool, list, str, unicode
+else:
+    def _get_primitive_type():
+        return int, float, bool, list, str

--- a/tests/multi-level-files/ns1/subdir/stuff.yaml
+++ b/tests/multi-level-files/ns1/subdir/stuff.yaml
@@ -1,3 +1,7 @@
 
 content2:
   key2: "value2"
+we:
+  need:
+    more:
+      cowbell: "ok"

--- a/tests/single-file/stuff.yaml
+++ b/tests/single-file/stuff.yaml
@@ -1,2 +1,5 @@
 
 key: "stuff-value"
+fruits:
+  - Apple
+  - Orange

--- a/tests/test_config_probe.py
+++ b/tests/test_config_probe.py
@@ -2,22 +2,32 @@ import unittest
 
 import os
 from config_probe import probe, fake_probe
-from hamcrest import is_, assert_that
+from config_probe.key_not_found_within_config_probe_patterns import KeyNotFoundWithinConfigProbePatterns
+from hamcrest import is_, assert_that, raises, calling
 
 
 class TestConfigProbe(unittest.TestCase):
-
     def test_single_file(self):
         config = probe(path=_dir("single-file"),
                        patterns=["stuff.yaml"])
 
         assert_that(config.key, is_("stuff-value"))
+        assert_that(config.fruits, is_(["Apple", "Orange"]))
 
     def test_single_file_with_namespace(self):
         config = probe(path=_dir("single-file-with-namespace"),
                        patterns=["(*).json"])
 
         assert_that(config.stuff.key, is_("stuff-value"))
+
+    def test_single_file_with_namespace_with_wrong_key(self):
+        config = probe(path=_dir("single-file-with-namespace"),
+                       patterns=["(*).json"])
+        assert_that(calling(self.config_with_inexistant_key).with_args(config),
+                    raises(KeyNotFoundWithinConfigProbePatterns))
+
+    def config_with_inexistant_key(self, config):
+        return config.stuff.key_inexistant
 
     def test_two_files_with_subdir_namespace(self):
         config = probe(path=_dir("two-files-with-subdir-namespace"),

--- a/tests/test_config_probe.py
+++ b/tests/test_config_probe.py
@@ -29,6 +29,16 @@ class TestConfigProbe(unittest.TestCase):
     def config_with_inexistant_key(self, config):
         return config.stuff.key_inexistant
 
+    def test_single_file_multiple_level_raising_or_not(self):
+        config = probe(path=_dir("multi-level-files"),
+                       patterns=["(*)/(*).yaml", "(*)/subdir/(*).yaml"])
+        assert_that(config.ns1.stuff.we.need.more.cowbell, is_("ok"))
+        assert_that(calling(self.config_with_multiple_level).with_args(config),
+                    raises(KeyNotFoundWithinConfigProbePatterns))
+
+    def config_with_multiple_level(self, config):
+        return config.ns1.stuff.we.need.less.cowbell
+
     def test_two_files_with_subdir_namespace(self):
         config = probe(path=_dir("two-files-with-subdir-namespace"),
                        patterns=["(*)/(*).yaml"])

--- a/tests/test_config_probe.py
+++ b/tests/test_config_probe.py
@@ -1,7 +1,7 @@
 import unittest
 
 import os
-/from config_probe import probe, fake_probe
+from config_probe import probe, fake_probe
 from config_probe.exceptions import ConfigNotFound
 from hamcrest import is_, assert_that
 

--- a/tests/test_config_probe.py
+++ b/tests/test_config_probe.py
@@ -1,7 +1,8 @@
 import unittest
 
 import os
-from config_probe import probe, fake_probe, ConfigNotFound
+/from config_probe import probe, fake_probe
+from config_probe.exceptions import ConfigNotFound
 from hamcrest import is_, assert_that
 
 

--- a/tests/test_config_probe.py
+++ b/tests/test_config_probe.py
@@ -1,9 +1,8 @@
 import unittest
 
 import os
-from config_probe import probe, fake_probe
-from config_probe.key_not_found_within_config_probe_patterns import KeyNotFoundWithinConfigProbePatterns
-from hamcrest import is_, assert_that, raises, calling
+from config_probe import probe, fake_probe, ConfigNotFound
+from hamcrest import is_, assert_that
 
 
 class TestConfigProbe(unittest.TestCase):
@@ -23,21 +22,17 @@ class TestConfigProbe(unittest.TestCase):
     def test_single_file_with_namespace_with_wrong_key(self):
         config = probe(path=_dir("single-file-with-namespace"),
                        patterns=["(*).json"])
-        assert_that(calling(self.config_with_inexistant_key).with_args(config),
-                    raises(KeyNotFoundWithinConfigProbePatterns))
 
-    def config_with_inexistant_key(self, config):
-        return config.stuff.key_inexistant
+        with self.assertRaises(ConfigNotFound):
+            print(config.stuff.key_inexistant)
 
     def test_single_file_multiple_level_raising_or_not(self):
         config = probe(path=_dir("multi-level-files"),
                        patterns=["(*)/(*).yaml", "(*)/subdir/(*).yaml"])
         assert_that(config.ns1.stuff.we.need.more.cowbell, is_("ok"))
-        assert_that(calling(self.config_with_multiple_level).with_args(config),
-                    raises(KeyNotFoundWithinConfigProbePatterns))
 
-    def config_with_multiple_level(self, config):
-        return config.ns1.stuff.we.need.less.cowbell
+        with self.assertRaises(ConfigNotFound):
+            print(config.ns1.stuff.we.need.less.cowbell)
 
     def test_two_files_with_subdir_namespace(self):
         config = probe(path=_dir("two-files-with-subdir-namespace"),


### PR DESCRIPTION
- Add wrapping for AttributeError to make it more clear
- Explicitly support list as a return type
