### PR TITLE
Add dictionary level merging

### DIFF
--- a/config_probe/__init__.py
+++ b/config_probe/__init__.py
@@ -2,6 +2,8 @@ import glob
 import json
 
 import os
+
+import collections
 import yaml
 from munch import munchify
 from config_probe.munch_wrapper import MunchWrapper
@@ -60,4 +62,12 @@ def _add_to_configuration(config, namespaces, new_values):
             current_level[ns] = {}
         current_level = current_level[ns]
 
-    current_level.update(new_values)
+    _update(current_level, new_values)
+
+
+def _update(config, values):
+    for k, v in values.items():
+        if k in config and isinstance(v, collections.Mapping):
+            _update(config[k], v)
+        else:
+            config[k] = v

--- a/tests/dict-merge/file1.yaml
+++ b/tests/dict-merge/file1.yaml
@@ -1,0 +1,9 @@
+
+mydict:
+  common_key: "value1"
+  only_in_1: "value1"
+  subdict:
+    common_list:
+      - "a1"
+      - "b1"
+    only_in_1: "value1"

--- a/tests/dict-merge/file2.yaml
+++ b/tests/dict-merge/file2.yaml
@@ -1,0 +1,9 @@
+
+mydict:
+  common_key: "value2"
+  only_in_2: "value2"
+  subdict:
+    common_list:
+      - "a2"
+      - "b2"
+    only_in_2: "value2"

--- a/tests/test_config_probe.py
+++ b/tests/test_config_probe.py
@@ -79,6 +79,25 @@ class TestConfigProbe(unittest.TestCase):
                        patterns=["file2.yaml", "file1.yaml"])
         assert_that(config.key, is_("value1"))
 
+    def test_yaml_dict_are_merged_list_arent(self):
+        config = probe(path=_dir("dict-merge"),
+                       patterns=["file1.yaml", "file2.yaml"])
+        assert_that(config.mydict.common_key, is_("value2"))
+        assert_that(config.mydict.only_in_1, is_("value1"))
+        assert_that(config.mydict.only_in_2, is_("value2"))
+        assert_that(config.mydict.subdict.common_list, is_(["a2", "b2"]))
+        assert_that(config.mydict.subdict.only_in_1, is_("value1"))
+        assert_that(config.mydict.subdict.only_in_2, is_("value2"))
+
+        config = probe(path=_dir("dict-merge"),
+                       patterns=["file2.yaml", "file1.yaml"])
+        assert_that(config.mydict.common_key, is_("value1"))
+        assert_that(config.mydict.only_in_1, is_("value1"))
+        assert_that(config.mydict.only_in_2, is_("value2"))
+        assert_that(config.mydict.subdict.common_list, is_(["a1", "b1"]))
+        assert_that(config.mydict.subdict.only_in_1, is_("value1"))
+        assert_that(config.mydict.subdict.only_in_2, is_("value2"))
+
     def test_support_for_empty_files(self):
         probe(path=_dir("empty-files"), patterns=["*.*"])
 


### PR DESCRIPTION
Now a dict is not different from a file or a namespace and
can be overwritten by the following entry

Use case is to support having

config.yaml
config.myenv.yaml

and have them both define a structure like

domain:
  subdomain:
     not_env_specific: ...
     env_specific: ...