### PR TITLE
Remove yaml unsafe deprecation warning

### DIFF
--- a/config_probe/__init__.py
+++ b/config_probe/__init__.py
@@ -37,7 +37,7 @@ def fake_probe(content):
 
 
 _parsers = {
-    ".yaml": lambda f: yaml.load(f) or {},
+    ".yaml": lambda f: yaml.safe_load(f) or {},
     ".json": lambda f: json.load(f),
 }
 


### PR DESCRIPTION
hides warning such has below in the projects using config-probe.
This will make sure that config-probe uses the safe yaml load version.
I don't see a valid reason to have injected code in your configuration
ifile.

This is a possibly breaking change.

YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated,
as the default Loader is unsafe.

Please read https://msg.pyyaml.org/load for full details.